### PR TITLE
Adding a verification for Google Search Console

### DIFF
--- a/google0c51c91905b705e7.html
+++ b/google0c51c91905b705e7.html
@@ -1,0 +1,1 @@
+google-site-verification: google0c51c91905b705e7.html


### PR DESCRIPTION
Seems weird that they would use an HTML file and not another format but this is one of the site ownership verification methods provided by Google directly, so I prostrate myself before the mighty gods of SEO and submit this sacrificial lamb. May it please them well.

If it doesn't work for any reason I will take it down.