### PR TITLE
Fix/776 - update DNA samples for iOS to version 3.15.1

### DIFF
--- a/ios/AVPlayer/DnaSample.xcodeproj/project.pbxproj
+++ b/ios/AVPlayer/DnaSample.xcodeproj/project.pbxproj
@@ -11,8 +11,8 @@
 		50F1DEB11E687C0E00B59D4B /* SwiftSampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F1DEB01E687C0E00B59D4B /* SwiftSampleViewController.swift */; };
 		50F1DEB41E687C0E00B59D4B /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 50F1DEB21E687C0E00B59D4B /* Main.storyboard */; };
 		50F1DEB91E687C0E00B59D4B /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 50F1DEB71E687C0E00B59D4B /* LaunchScreen.storyboard */; };
-		6ACC9D5FA263704EF1B5FFB7 /* Pods_DnaSample_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FEB302E3BF73EBCF7E4CB1E0 /* Pods_DnaSample_iOS.framework */; };
-		7C86F8AC7B0660DBCB0199DB /* Pods_DnaSample_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B8C493CB6F7FF9FA038EBB4 /* Pods_DnaSample_tvOS.framework */; };
+		7C75C53BB278C24E2097CBF1 /* Pods_DnaSample_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EA45C18AE4D9352919B2BC7E /* Pods_DnaSample_iOS.framework */; };
+		948205D90FAB75E67FE891D0 /* Pods_DnaSample_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2E2106B2377C9CEA6C8ADAF9 /* Pods_DnaSample_tvOS.framework */; };
 		D61171C2209B06F100CBE36B /* ObjCSampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D61171C0209B06F000CBE36B /* ObjCSampleViewController.m */; };
 		D61171CE209B200900CBE36B /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61171CD209B200900CBE36B /* MainViewController.swift */; };
 		D61171F2209B3FAD00CBE36B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D61171F1209B3FAD00CBE36B /* Assets.xcassets */; };
@@ -39,7 +39,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		1E6CF5E657E1CBC8F373DE26 /* Pods-DnaSample-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DnaSample-tvOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-DnaSample-tvOS/Pods-DnaSample-tvOS.release.xcconfig"; sourceTree = "<group>"; };
+		2E2106B2377C9CEA6C8ADAF9 /* Pods_DnaSample_tvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_DnaSample_tvOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4D6B85E428E23BE7A006CE55 /* Pods-DnaSample-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DnaSample-iOS.debug.xcconfig"; path = "Target Support Files/Pods-DnaSample-iOS/Pods-DnaSample-iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		50F1DEAB1E687C0E00B59D4B /* DnaSample-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "DnaSample-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		50F1DEAE1E687C0E00B59D4B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		50F1DEB01E687C0E00B59D4B /* SwiftSampleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftSampleViewController.swift; sourceTree = "<group>"; };
@@ -47,9 +48,8 @@
 		50F1DEB51E687C0E00B59D4B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		50F1DEB81E687C0E00B59D4B /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		50F1DEBA1E687C0E00B59D4B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		673F1767437FC1E30FAE5252 /* Pods-DnaSample-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DnaSample-tvOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-DnaSample-tvOS/Pods-DnaSample-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
-		7925FD0A65D756B1D1E5BF33 /* Pods-DnaSample-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DnaSample-iOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-DnaSample-iOS/Pods-DnaSample-iOS.debug.xcconfig"; sourceTree = "<group>"; };
-		7B8C493CB6F7FF9FA038EBB4 /* Pods_DnaSample_tvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_DnaSample_tvOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9AD2CA3DD79A53C2C4D7A8D2 /* Pods-DnaSample-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DnaSample-iOS.release.xcconfig"; path = "Target Support Files/Pods-DnaSample-iOS/Pods-DnaSample-iOS.release.xcconfig"; sourceTree = "<group>"; };
+		C53DCE19EFE421017A1EFC7F /* Pods-DnaSample-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DnaSample-tvOS.release.xcconfig"; path = "Target Support Files/Pods-DnaSample-tvOS/Pods-DnaSample-tvOS.release.xcconfig"; sourceTree = "<group>"; };
 		D6087576219079F50034CB62 /* SwiftPluginSampleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftPluginSampleViewController.swift; sourceTree = "<group>"; };
 		D61171BF209B06F000CBE36B /* DnaSample-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "DnaSample-Bridging-Header.h"; sourceTree = "<group>"; };
 		D61171C0209B06F000CBE36B /* ObjCSampleViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjCSampleViewController.m; sourceTree = "<group>"; };
@@ -65,8 +65,8 @@
 		D6CA02042232BE5C00FC025E /* libresolv.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libresolv.tbd; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.1.sdk/usr/lib/libresolv.tbd; sourceTree = DEVELOPER_DIR; };
 		D6CA02062232BEC000FC025E /* librust_app_ios.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = librust_app_ios.a; sourceTree = "<group>"; };
 		D6CA020E2232C34200FC025E /* libresolv.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libresolv.tbd; path = usr/lib/libresolv.tbd; sourceTree = SDKROOT; };
-		DBCAADD7ED7212625103F9D6 /* Pods-DnaSample-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DnaSample-iOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-DnaSample-iOS/Pods-DnaSample-iOS.release.xcconfig"; sourceTree = "<group>"; };
-		FEB302E3BF73EBCF7E4CB1E0 /* Pods_DnaSample_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_DnaSample_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DAC6D4012E2CBAECD8561555 /* Pods-DnaSample-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DnaSample-tvOS.debug.xcconfig"; path = "Target Support Files/Pods-DnaSample-tvOS/Pods-DnaSample-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
+		EA45C18AE4D9352919B2BC7E /* Pods_DnaSample_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_DnaSample_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -74,7 +74,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6ACC9D5FA263704EF1B5FFB7 /* Pods_DnaSample_iOS.framework in Frameworks */,
+				7C75C53BB278C24E2097CBF1 /* Pods_DnaSample_iOS.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -82,32 +82,21 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7C86F8AC7B0660DBCB0199DB /* Pods_DnaSample_tvOS.framework in Frameworks */,
+				948205D90FAB75E67FE891D0 /* Pods_DnaSample_tvOS.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		4FCAE8478A911E4AF4BC7C65 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				7925FD0A65D756B1D1E5BF33 /* Pods-DnaSample-iOS.debug.xcconfig */,
-				DBCAADD7ED7212625103F9D6 /* Pods-DnaSample-iOS.release.xcconfig */,
-				673F1767437FC1E30FAE5252 /* Pods-DnaSample-tvOS.debug.xcconfig */,
-				1E6CF5E657E1CBC8F373DE26 /* Pods-DnaSample-tvOS.release.xcconfig */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
 		50F1DEA21E687C0E00B59D4B = {
 			isa = PBXGroup;
 			children = (
 				50F1DEAD1E687C0E00B59D4B /* DnaSample */,
 				D61171E9209B3FAB00CBE36B /* DnaSample-tvOS */,
 				50F1DEAC1E687C0E00B59D4B /* Products */,
-				4FCAE8478A911E4AF4BC7C65 /* Pods */,
 				70434333EC1714347C4161DA /* Frameworks */,
+				B80B6ED10A887749320E0283 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -143,10 +132,21 @@
 				D6CA020E2232C34200FC025E /* libresolv.tbd */,
 				D6CA02062232BEC000FC025E /* librust_app_ios.a */,
 				D6CA02042232BE5C00FC025E /* libresolv.tbd */,
-				FEB302E3BF73EBCF7E4CB1E0 /* Pods_DnaSample_iOS.framework */,
-				7B8C493CB6F7FF9FA038EBB4 /* Pods_DnaSample_tvOS.framework */,
+				EA45C18AE4D9352919B2BC7E /* Pods_DnaSample_iOS.framework */,
+				2E2106B2377C9CEA6C8ADAF9 /* Pods_DnaSample_tvOS.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		B80B6ED10A887749320E0283 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				4D6B85E428E23BE7A006CE55 /* Pods-DnaSample-iOS.debug.xcconfig */,
+				9AD2CA3DD79A53C2C4D7A8D2 /* Pods-DnaSample-iOS.release.xcconfig */,
+				DAC6D4012E2CBAECD8561555 /* Pods-DnaSample-tvOS.debug.xcconfig */,
+				C53DCE19EFE421017A1EFC7F /* Pods-DnaSample-tvOS.release.xcconfig */,
+			);
+			path = Pods;
 			sourceTree = "<group>";
 		};
 		D61171C3209B072300CBE36B /* ObjC */ = {
@@ -194,11 +194,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 50F1DEBD1E687C0E00B59D4B /* Build configuration list for PBXNativeTarget "DnaSample-iOS" */;
 			buildPhases = (
-				3C615CC52A735F39A95EF424 /* [CP] Check Pods Manifest.lock */,
+				A000AA0FA48E68484CC01558 /* [CP] Check Pods Manifest.lock */,
 				50F1DEA71E687C0E00B59D4B /* Sources */,
 				50F1DEA81E687C0E00B59D4B /* Frameworks */,
 				50F1DEA91E687C0E00B59D4B /* Resources */,
-				995A221F3CB0C5495640F0BF /* [CP] Embed Pods Frameworks */,
+				893168EFD9FE7291BF472F3F /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -213,12 +213,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = D61171F6209B3FAD00CBE36B /* Build configuration list for PBXNativeTarget "DnaSample-tvOS" */;
 			buildPhases = (
-				B1B248BEB1183D7F53988A8D /* [CP] Check Pods Manifest.lock */,
+				CB742E150E45F7BEE8C522FC /* [CP] Check Pods Manifest.lock */,
 				D61171E4209B3FAB00CBE36B /* Sources */,
 				D61171E6209B3FAB00CBE36B /* Resources */,
 				D61171E5209B3FAB00CBE36B /* Frameworks */,
 				D62DA02221AFE80700503262 /* CopyFiles */,
-				444208E17B498CC115F829E7 /* [CP] Embed Pods Frameworks */,
+				252CE7E2DAF707FE390DBBDA /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -296,29 +296,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		3C615CC52A735F39A95EF424 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-DnaSample-iOS-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		444208E17B498CC115F829E7 /* [CP] Embed Pods Frameworks */ = {
+		252CE7E2DAF707FE390DBBDA /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -346,7 +324,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-DnaSample-tvOS/Pods-DnaSample-tvOS-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		995A221F3CB0C5495640F0BF /* [CP] Embed Pods Frameworks */ = {
+		893168EFD9FE7291BF472F3F /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -376,7 +354,29 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-DnaSample-iOS/Pods-DnaSample-iOS-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		B1B248BEB1183D7F53988A8D /* [CP] Check Pods Manifest.lock */ = {
+		A000AA0FA48E68484CC01558 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-DnaSample-iOS-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		CB742E150E45F7BEE8C522FC /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -568,7 +568,7 @@
 		};
 		50F1DEBE1E687C0E00B59D4B /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7925FD0A65D756B1D1E5BF33 /* Pods-DnaSample-iOS.debug.xcconfig */;
+			baseConfigurationReference = 4D6B85E428E23BE7A006CE55 /* Pods-DnaSample-iOS.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -600,7 +600,7 @@
 		};
 		50F1DEBF1E687C0E00B59D4B /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DBCAADD7ED7212625103F9D6 /* Pods-DnaSample-iOS.release.xcconfig */;
+			baseConfigurationReference = 9AD2CA3DD79A53C2C4D7A8D2 /* Pods-DnaSample-iOS.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -631,7 +631,7 @@
 		};
 		D61171F4209B3FAD00CBE36B /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 673F1767437FC1E30FAE5252 /* Pods-DnaSample-tvOS.debug.xcconfig */;
+			baseConfigurationReference = DAC6D4012E2CBAECD8561555 /* Pods-DnaSample-tvOS.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "Brand Assets";
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -657,7 +657,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = appletvos;
-				SWIFT_OBJC_BRIDGING_HEADER = "/Users/laminendiaye/Documents/Projects/Integration/DNA/dna-integration-samples/ios/AVPlayer/DnaSample/DnaSample-Bridging-Header.h";
+				SWIFT_OBJC_BRIDGING_HEADER = "DnaSample/DnaSample-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 10.2;
@@ -666,7 +666,7 @@
 		};
 		D61171F5209B3FAD00CBE36B /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1E6CF5E657E1CBC8F373DE26 /* Pods-DnaSample-tvOS.release.xcconfig */;
+			baseConfigurationReference = C53DCE19EFE421017A1EFC7F /* Pods-DnaSample-tvOS.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "Brand Assets";
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -692,7 +692,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = appletvos;
-				SWIFT_OBJC_BRIDGING_HEADER = "/Users/laminendiaye/Documents/Projects/Integration/DNA/dna-integration-samples/ios/AVPlayer/DnaSample/DnaSample-Bridging-Header.h";
+				SWIFT_OBJC_BRIDGING_HEADER = "DnaSample/DnaSample-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 10.2;

--- a/ios/AVPlayer/DnaSample.xcodeproj/xcshareddata/xcschemes/DnaSample-tvOS.xcscheme
+++ b/ios/AVPlayer/DnaSample.xcodeproj/xcshareddata/xcschemes/DnaSample-tvOS.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1030"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D61171E7209B3FAB00CBE36B"
+               BuildableName = "DnaSample-tvOS.app"
+               BlueprintName = "DnaSample-tvOS"
+               ReferencedContainer = "container:DnaSample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D61171E7209B3FAB00CBE36B"
+            BuildableName = "DnaSample-tvOS.app"
+            BlueprintName = "DnaSample-tvOS"
+            ReferencedContainer = "container:DnaSample.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D61171E7209B3FAB00CBE36B"
+            BuildableName = "DnaSample-tvOS.app"
+            BlueprintName = "DnaSample-tvOS"
+            ReferencedContainer = "container:DnaSample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D61171E7209B3FAB00CBE36B"
+            BuildableName = "DnaSample-tvOS.app"
+            BlueprintName = "DnaSample-tvOS"
+            ReferencedContainer = "container:DnaSample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios/AVPlayer/DnaSample/GoogleDAI/DNAAAVPlayerVideoDisplay.swift
+++ b/ios/AVPlayer/DnaSample/GoogleDAI/DNAAAVPlayerVideoDisplay.swift
@@ -14,13 +14,13 @@ import StreamrootSDK
 // MARK: - Configuration
 
 struct DNAConfiguration {
-  let streamrootKey: String
+  let streamrootKey: String?
   let contentId: String?
   let latency: Int
   let property: String?
   let backendHost: URL?
   
-  init(streamrootKey: String,
+    init(streamrootKey: String? = nil,
        contentId: String? = nil,
        latency: Int = 0,
        property: String? = nil,
@@ -39,7 +39,7 @@ class DNAAVPlayerVideoDisplay: IMAAVPlayerVideoDisplay {
   private(set) var dnaClient: DNAClient?
   private(set) var dnaConfig: DNAConfiguration
   
-  private var strKey: String {
+  private var strKey: String? {
     return self.dnaConfig.streamrootKey
   }
   
@@ -77,7 +77,9 @@ extension DNAAVPlayerVideoDisplay {
   func startStreamURL(_ url: URL) throws -> URL? {
     print("🔥 starting DNA builder \(Date().timeIntervalSince1970)")
     var builder = DNAClient.builder().dnaClientDelegate(self)
-    builder = builder.streamrootKey(strKey)
+    if let strKey = strKey, !strKey.isEmpty {
+        builder = builder.streamrootKey(strKey)
+    }
     
     if self.latency > 0 {
       builder = builder.latency(self.latency)

--- a/ios/AVPlayer/DnaSample/GoogleDAI/GoogleDAISampleViewController.swift
+++ b/ios/AVPlayer/DnaSample/GoogleDAI/GoogleDAISampleViewController.swift
@@ -39,12 +39,14 @@ extension GoogleDAISampleViewController {
   
   func requestStream() {
     print("🔥 request stream \(Date().timeIntervalSince1970)")
-    let streamrootKey = (Bundle.main.infoDictionary?["Streamroot"] as? [String:Any])?["Key"] as? String ?? ""
     let adDisplayContainer = IMAAdDisplayContainer(adContainer: contentOverlayView!, companionSlots: nil)
-    let config = DNAConfiguration(streamrootKey: streamrootKey,
-                                  contentId: "GoogleDAI_TEST",
-                                  latency: 30,
-                                  property:  "SSAI")
+    // the streamroot key will default to the one in the Info.plist if not overridden here
+    let config = DNAConfiguration(
+        //streamrootKey: "demoswebsiteandpartners",
+        contentId: "GoogleDAI_TEST",
+        latency: 30,
+        property:  "SSAI"
+    )
     videoDisplay = DNAAVPlayerVideoDisplay(avPlayer: player, dnaConfig: config)
     videoDisplay?.avPlayerVideoDisplayDelegate = self
     let request = IMALiveStreamRequest(assetKey: "sN_IYUG8STe1ZzhIIE_ksA",

--- a/ios/AVPlayer/DnaSample/GoogleDAI/GoogleDAISampleViewController.swift
+++ b/ios/AVPlayer/DnaSample/GoogleDAI/GoogleDAISampleViewController.swift
@@ -39,8 +39,9 @@ extension GoogleDAISampleViewController {
   
   func requestStream() {
     print("🔥 request stream \(Date().timeIntervalSince1970)")
+    let streamrootKey = (Bundle.main.infoDictionary?["Streamroot"] as? [String:Any])?["Key"] as? String ?? ""
     let adDisplayContainer = IMAAdDisplayContainer(adContainer: contentOverlayView!, companionSlots: nil)
-    let config = DNAConfiguration(streamrootKey:  "laminendiaye",
+    let config = DNAConfiguration(streamrootKey: streamrootKey,
                                   contentId: "GoogleDAI_TEST",
                                   latency: 30,
                                   property:  "SSAI")

--- a/ios/AVPlayer/DnaSample/Info.plist
+++ b/ios/AVPlayer/DnaSample/Info.plist
@@ -28,7 +28,7 @@
 	<key>Streamroot</key>
 	<dict>
 		<key>Key</key>
-		<string>borisborgobello</string>
+		<string>demoswebsiteandpartners</string>
 	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>

--- a/ios/AVPlayer/DnaSample/Info.plist
+++ b/ios/AVPlayer/DnaSample/Info.plist
@@ -28,7 +28,7 @@
 	<key>Streamroot</key>
 	<dict>
 		<key>Key</key>
-		<string>demoswebsiteandpartners</string>
+		<string>borisborgobello</string>
 	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>

--- a/ios/AVPlayer/DnaSample/ObjC/ObjCSampleViewController.m
+++ b/ios/AVPlayer/DnaSample/ObjC/ObjCSampleViewController.m
@@ -22,12 +22,13 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
   
-    NSString *streamrootKey = [[NSBundle mainBundle] infoDictionary][@"Streamroot"][@"Key"];
     NSURL *manifestUrl = [NSURL URLWithString: @"http://wowza-test.streamroot.io/liveOrigin/BBB-bl-1500/playlist.m3u8"];
     NSError *error;
-   // the streamroot key can be set in the config or in the mainPlist file
-  self.dnaClient = [[[[DNAClient.builder dnaClientDelegate: self] latency: 30]
-                    streamrootKey: streamrootKey ? streamrootKey : @""]
+    
+    // the streamroot key will default to the one in the Info.plist if not overridden here
+  self.dnaClient = [/*[*/[[DNAClient.builder dnaClientDelegate: self]
+                      latency: 30]
+                      //streamrootKey: @"demoswebsiteandpartners"]
                     start:manifestUrl error: &error];
   if (error || !self.dnaClient) {
     NSLog(@"error: %@", error);

--- a/ios/AVPlayer/DnaSample/ObjC/ObjCSampleViewController.m
+++ b/ios/AVPlayer/DnaSample/ObjC/ObjCSampleViewController.m
@@ -22,11 +22,12 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
   
+    NSString *streamrootKey = [[NSBundle mainBundle] infoDictionary][@"Streamroot"][@"Key"];
     NSURL *manifestUrl = [NSURL URLWithString: @"http://wowza-test.streamroot.io/liveOrigin/BBB-bl-1500/playlist.m3u8"];
     NSError *error;
    // the streamroot key can be set in the config or in the mainPlist file
   self.dnaClient = [[[[DNAClient.builder dnaClientDelegate: self] latency: 30]
-                    streamrootKey: @"demoswebsiteandpartners"]
+                    streamrootKey: streamrootKey ? streamrootKey : @""]
                     start:manifestUrl error: &error];
   if (error || !self.dnaClient) {
     NSLog(@"error: %@", error);

--- a/ios/AVPlayer/DnaSample/Swift/SwiftPluginSampleViewController.swift
+++ b/ios/AVPlayer/DnaSample/Swift/SwiftPluginSampleViewController.swift
@@ -13,7 +13,6 @@ import AVKit
 class SwiftPluginSampleViewController: AVPlayerViewController {
 
   var strPlugin: StreamrootPlugin?
-  private let streamrootKey = (Bundle.main.infoDictionary?["Streamroot"] as? [String:Any])?["Key"] as? String ?? ""
   private let manifestUrl = URL(string: "http://wowza-test.streamroot.io/liveOrigin/BBB-bl-1500/playlist.m3u8")!
   
   override func viewDidDisappear(_ animated: Bool) {
@@ -22,8 +21,8 @@ class SwiftPluginSampleViewController: AVPlayerViewController {
   
   override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
-    let config = DNAConfig(streamrootKey: streamrootKey)
-    // the streamroot key can be set in the config or in the mainPlist file
+    let config = DNAConfig(/*streamrootKey: "demoswebsiteandpartners"*/)
+    // the streamroot key will default to the one in the Info.plist if not overridden here
     config.latency = 30
     strPlugin = AVPlayerDNAPlugin(manifestUrl: manifestUrl, config: config)
     do {

--- a/ios/AVPlayer/DnaSample/Swift/SwiftPluginSampleViewController.swift
+++ b/ios/AVPlayer/DnaSample/Swift/SwiftPluginSampleViewController.swift
@@ -13,6 +13,7 @@ import AVKit
 class SwiftPluginSampleViewController: AVPlayerViewController {
 
   var strPlugin: StreamrootPlugin?
+  private let streamrootKey = (Bundle.main.infoDictionary?["Streamroot"] as? [String:Any])?["Key"] as? String ?? ""
   private let manifestUrl = URL(string: "http://wowza-test.streamroot.io/liveOrigin/BBB-bl-1500/playlist.m3u8")!
   
   override func viewDidDisappear(_ animated: Bool) {
@@ -21,7 +22,7 @@ class SwiftPluginSampleViewController: AVPlayerViewController {
   
   override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
-    let config = DNAConfig(streamrootKey: "demoswebsiteandpartners")
+    let config = DNAConfig(streamrootKey: streamrootKey)
     // the streamroot key can be set in the config or in the mainPlist file
     config.latency = 30
     strPlugin = AVPlayerDNAPlugin(manifestUrl: manifestUrl, config: config)

--- a/ios/AVPlayer/DnaSample/Swift/SwiftSampleViewController.swift
+++ b/ios/AVPlayer/DnaSample/Swift/SwiftSampleViewController.swift
@@ -12,6 +12,7 @@ import StreamrootSDK
 
 class SwiftSampleViewController: AVPlayerViewController {
   var dnaClient: DNAClient?
+  private let streamrootKey = (Bundle.main.infoDictionary?["Streamroot"] as? [String:Any])?["Key"] as? String ?? ""
   private let manifestUrl = URL(string: "http://wowza-test.streamroot.io/liveOrigin/BBB-bl-1500/playlist.m3u8")!
   
   override func viewDidDisappear(_ animated: Bool) {
@@ -24,7 +25,7 @@ class SwiftSampleViewController: AVPlayerViewController {
       dnaClient = try DNAClient.builder()
         .dnaClientDelegate(self)
         // the streamroot key can be set in the config or in the mainPlist file
-        .streamrootKey("demoswebsiteandpartners")
+        .streamrootKey(streamrootKey)
         .latency(30)
         .start(manifestUrl)
     } catch let error {

--- a/ios/AVPlayer/DnaSample/Swift/SwiftSampleViewController.swift
+++ b/ios/AVPlayer/DnaSample/Swift/SwiftSampleViewController.swift
@@ -12,7 +12,6 @@ import StreamrootSDK
 
 class SwiftSampleViewController: AVPlayerViewController {
   var dnaClient: DNAClient?
-  private let streamrootKey = (Bundle.main.infoDictionary?["Streamroot"] as? [String:Any])?["Key"] as? String ?? ""
   private let manifestUrl = URL(string: "http://wowza-test.streamroot.io/liveOrigin/BBB-bl-1500/playlist.m3u8")!
   
   override func viewDidDisappear(_ animated: Bool) {
@@ -24,8 +23,8 @@ class SwiftSampleViewController: AVPlayerViewController {
     do {
       dnaClient = try DNAClient.builder()
         .dnaClientDelegate(self)
-        // the streamroot key can be set in the config or in the mainPlist file
-        .streamrootKey(streamrootKey)
+        // the streamroot key will default to the one in the Info.plist if not overridden here
+        //.streamrootKey("demoswebsiteandpartners")
         .latency(30)
         .start(manifestUrl)
     } catch let error {

--- a/ios/AVPlayer/Podfile.lock
+++ b/ios/AVPlayer/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
-  - AVPlayerDNAPlugin (1.1.11):
-    - StreamrootSDK (~> 3.15.0)
+  - AVPlayerDNAPlugin (1.1.12):
+    - StreamrootSDK (~> 3.15.1)
   - GoogleAds-IMA-iOS-SDK (3.10.1)
   - Sentry (4.4.0):
     - Sentry/Core (= 4.4.0)
@@ -26,7 +26,7 @@ SPEC REPOS:
     - SwiftProtobuf
 
 SPEC CHECKSUMS:
-  AVPlayerDNAPlugin: 7d4531cb05444f30006a7a4569afaadbd0260730
+  AVPlayerDNAPlugin: fb0a52a327e9dc7cb9b3b43a912857c66363febc
   GoogleAds-IMA-iOS-SDK: 0e37ab83b22075ad631a70dcba9528cb246c92bf
   Sentry: 26650184fe71eb7476dfd2737acb5ea6cc64b4b1
   Starscream: 08172b481e145289c4930cb567230fb55897cfa4

--- a/ios/AVPlayer/Podfile.lock
+++ b/ios/AVPlayer/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
     - Sentry/Core (= 4.4.0)
   - Sentry/Core (4.4.0)
   - Starscream (3.1.0)
-  - StreamrootSDK (3.15.0):
+  - StreamrootSDK (3.15.1):
     - Sentry (= 4.4.0)
     - Starscream (= 3.1.0)
     - SwiftProtobuf (= 1.6.0)
@@ -30,7 +30,7 @@ SPEC CHECKSUMS:
   GoogleAds-IMA-iOS-SDK: 0e37ab83b22075ad631a70dcba9528cb246c92bf
   Sentry: 26650184fe71eb7476dfd2737acb5ea6cc64b4b1
   Starscream: 08172b481e145289c4930cb567230fb55897cfa4
-  StreamrootSDK: 91d4db6a75cef993f64137c5c5edb830c0cc198b
+  StreamrootSDK: 9c7616fe7ba17b921ed4d73d8b8a051027c22690
   SwiftProtobuf: e905ca1366405696411aaf174411c4b19c0ef73d
 
 PODFILE CHECKSUM: 9161faea9d1bf3934e245a45155204e552321028

--- a/ios/AVPlayer/Podfile.lock
+++ b/ios/AVPlayer/Podfile.lock
@@ -1,12 +1,12 @@
 PODS:
-  - AVPlayerDNAPlugin (1.1.10):
-    - StreamrootSDK (~> 3.14.0)
-  - GoogleAds-IMA-iOS-SDK (3.9.0)
+  - AVPlayerDNAPlugin (1.1.11):
+    - StreamrootSDK (~> 3.15.0)
+  - GoogleAds-IMA-iOS-SDK (3.10.1)
   - Sentry (4.4.0):
     - Sentry/Core (= 4.4.0)
   - Sentry/Core (4.4.0)
   - Starscream (3.1.0)
-  - StreamrootSDK (3.14.0):
+  - StreamrootSDK (3.15.0):
     - Sentry (= 4.4.0)
     - Starscream (= 3.1.0)
     - SwiftProtobuf (= 1.6.0)
@@ -26,11 +26,11 @@ SPEC REPOS:
     - SwiftProtobuf
 
 SPEC CHECKSUMS:
-  AVPlayerDNAPlugin: 1e14f56f2e88bd53c1ffa34fc5f3c869b49cd614
-  GoogleAds-IMA-iOS-SDK: 8f57879738137b81a48ba792e42439e6bff5413b
+  AVPlayerDNAPlugin: 7d4531cb05444f30006a7a4569afaadbd0260730
+  GoogleAds-IMA-iOS-SDK: 0e37ab83b22075ad631a70dcba9528cb246c92bf
   Sentry: 26650184fe71eb7476dfd2737acb5ea6cc64b4b1
   Starscream: 08172b481e145289c4930cb567230fb55897cfa4
-  StreamrootSDK: 3c2b98c206133ca9c45b377ddef3b1f0c36e5923
+  StreamrootSDK: 91d4db6a75cef993f64137c5c5edb830c0cc198b
   SwiftProtobuf: e905ca1366405696411aaf174411c4b19c0ef73d
 
 PODFILE CHECKSUM: 9161faea9d1bf3934e245a45155204e552321028

--- a/ios/Brightcove/CustomControls.xcodeproj/xcshareddata/xcschemes/CustomControls.xcscheme
+++ b/ios/Brightcove/CustomControls.xcodeproj/xcshareddata/xcschemes/CustomControls.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1030"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E9DEE4FC216CEC430033C285"
+               BuildableName = "CustomControls.app"
+               BlueprintName = "CustomControls"
+               ReferencedContainer = "container:CustomControls.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E9DEE4FC216CEC430033C285"
+            BuildableName = "CustomControls.app"
+            BlueprintName = "CustomControls"
+            ReferencedContainer = "container:CustomControls.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E9DEE4FC216CEC430033C285"
+            BuildableName = "CustomControls.app"
+            BlueprintName = "CustomControls"
+            ReferencedContainer = "container:CustomControls.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E9DEE4FC216CEC430033C285"
+            BuildableName = "CustomControls.app"
+            BlueprintName = "CustomControls"
+            ReferencedContainer = "container:CustomControls.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios/Brightcove/Podfile.lock
+++ b/ios/Brightcove/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
     - Sentry/Core (= 4.4.0)
   - Sentry/Core (4.4.0)
   - Starscream (3.1.0)
-  - StreamrootSDK (3.14.0):
+  - StreamrootSDK (3.15.1):
     - Sentry (= 4.4.0)
     - Starscream (= 3.1.0)
     - SwiftProtobuf (= 1.6.0)
@@ -27,7 +27,7 @@ SPEC CHECKSUMS:
   Brightcove-Player-Core: bcd099cdc27a807ae23fcf22ecfb1eb52c72980c
   Sentry: 26650184fe71eb7476dfd2737acb5ea6cc64b4b1
   Starscream: 08172b481e145289c4930cb567230fb55897cfa4
-  StreamrootSDK: 3c2b98c206133ca9c45b377ddef3b1f0c36e5923
+  StreamrootSDK: 9c7616fe7ba17b921ed4d73d8b8a051027c22690
   SwiftProtobuf: e905ca1366405696411aaf174411c4b19c0ef73d
 
 PODFILE CHECKSUM: b53b13a593ea492bf144078fdb41dec72e794e60

--- a/ios/Brightcove_SSAI/Podfile.lock
+++ b/ios/Brightcove_SSAI/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
     - Sentry/Core (= 4.4.0)
   - Sentry/Core (4.4.0)
   - Starscream (3.1.0)
-  - StreamrootSDK (3.14.0):
+  - StreamrootSDK (3.15.1):
     - Sentry (= 4.4.0)
     - Starscream (= 3.1.0)
     - SwiftProtobuf (= 1.6.0)
@@ -31,7 +31,7 @@ SPEC CHECKSUMS:
   Brightcove-Player-SSAI: 5f37aa6bc4318346f4b5c0cad8c898773eadc01f
   Sentry: 26650184fe71eb7476dfd2737acb5ea6cc64b4b1
   Starscream: 08172b481e145289c4930cb567230fb55897cfa4
-  StreamrootSDK: 3c2b98c206133ca9c45b377ddef3b1f0c36e5923
+  StreamrootSDK: 9c7616fe7ba17b921ed4d73d8b8a051027c22690
   SwiftProtobuf: e905ca1366405696411aaf174411c4b19c0ef73d
 
 PODFILE CHECKSUM: 479502283cd0cd74713787f5537f633693792fd3

--- a/ios/PhoenixAnalyticsSample/PhoenixAnalyticsSample-Swift/PlayKitQoSModule.swift
+++ b/ios/PhoenixAnalyticsSample/PhoenixAnalyticsSample-Swift/PlayKitQoSModule.swift
@@ -12,7 +12,7 @@ import StreamrootSDK
 // Streamroot QoS module
 // Binds player' events to raise precise data to DNAClient
 class PlayKitQoSModule {
-    let dnaQoSModule: QosModule = StreamrootQosModule(moduleType: .custom)
+    let dnaQoSModule: QosModule = DNAQos.module(type: .custom)
 
     public init(_ player: Player) {
         player.addObserver(self, event: PlayerEvent.stateChanged, block: { event in

--- a/ios/PhoenixAnalyticsSample/Podfile
+++ b/ios/PhoenixAnalyticsSample/Podfile
@@ -35,7 +35,7 @@ abstract_target 'SharedPods' do
       pod 'PlayKitProviders'
     end
   end
-  pod 'StreamrootSDK', '~> 3.12.0'
+  pod 'StreamrootSDK'
 
 
   target 'PhoenixAnalyticsSample-Swift'

--- a/ios/PhoenixAnalyticsSample/Podfile.lock
+++ b/ios/PhoenixAnalyticsSample/Podfile.lock
@@ -15,21 +15,21 @@ PODS:
     - PlayKitUtils (~> 0.4.0)
     - SwiftyJSON (= 4.3.0)
     - XCGLogger (= 7.0.0)
-  - PlayKitProviders (1.3.1):
+  - PlayKitProviders (1.4.0):
     - KalturaNetKit
     - PlayKit/AnalyticsCommon
     - PlayKitUtils
     - SwiftyXMLParser (= 5.0.0)
   - PlayKitUtils (0.4.0)
-  - Sentry (4.3.1):
-    - Sentry/Core (= 4.3.1)
-  - Sentry/Core (4.3.1)
+  - Sentry (4.4.0):
+    - Sentry/Core (= 4.4.0)
+  - Sentry/Core (4.4.0)
   - Starscream (3.1.0)
-  - StreamrootSDK (3.12.0):
-    - Sentry (= 4.3.1)
+  - StreamrootSDK (3.15.1):
+    - Sentry (= 4.4.0)
     - Starscream (= 3.1.0)
-    - SwiftProtobuf (= 1.4.0)
-  - SwiftProtobuf (1.4.0)
+    - SwiftProtobuf (= 1.6.0)
+  - SwiftProtobuf (1.6.0)
   - SwiftyJSON (4.3.0)
   - SwiftyXMLParser (5.0.0)
   - XCGLogger (7.0.0):
@@ -40,7 +40,7 @@ PODS:
 DEPENDENCIES:
   - PlayKit (from `https://github.com/streamroot/playkit-ios`, branch `preferredForwardBufferDuration`)
   - PlayKitProviders
-  - StreamrootSDK (~> 3.12.0)
+  - StreamrootSDK
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -70,16 +70,16 @@ SPEC CHECKSUMS:
   KalturaNetKit: bd5a963f23f3917a059ac374406143fe2d29bf27
   ObjcExceptionBridging: c30e00eb3700467e695faeea30e26e18bd445001
   PlayKit: 46da5b32b306122fda6232547234d7fe9a3bb77b
-  PlayKitProviders: 530412b94b67e9f8faa73788da1bd0865bb67b89
+  PlayKitProviders: 47acfb2a297b9ea01fa89539614b97e6ab95a1f0
   PlayKitUtils: 98bffe139cffe5cb1fe8fc757b58845c939caf67
-  Sentry: 5267d493a398663538317e4dcc438c12c66202ed
+  Sentry: 26650184fe71eb7476dfd2737acb5ea6cc64b4b1
   Starscream: 08172b481e145289c4930cb567230fb55897cfa4
-  StreamrootSDK: e1e7bc26e70c406fb3ae902cf45bf081c18f4cd2
-  SwiftProtobuf: b06646ed6cdcfc3fecd074c6000fe0c413140e4f
+  StreamrootSDK: 9c7616fe7ba17b921ed4d73d8b8a051027c22690
+  SwiftProtobuf: e905ca1366405696411aaf174411c4b19c0ef73d
   SwiftyJSON: 6faa0040f8b59dead0ee07436cbf76b73c08fd08
   SwiftyXMLParser: 5ebb8793192f403fa8cc691045143906122a7a75
   XCGLogger: 0434f15e3909cdc450bb63faf638b8792ab782ab
 
-PODFILE CHECKSUM: f0b3a9015168fc7e3648b662faa9656a2706312b
+PODFILE CHECKSUM: 4bc3f170f7a07b8e301ff9a082ef942b7711cae9
 
-COCOAPODS: 1.7.0
+COCOAPODS: 1.7.5

--- a/ios/PlayKit/PlayKit/PlayKitQosModuleWrapper.h
+++ b/ios/PlayKit/PlayKit/PlayKitQosModuleWrapper.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface PlayKitQosModuleWrapper : NSObject
 +(instancetype)playKitQoSModule:(id<Player>) player;
-@property (nonatomic, strong) StreamrootQosModule *dnaQoSModule;
+@property (nonatomic, strong) id<QosModule> dnaQoSModule;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/PlayKit/PlayKit/PlayKitQosModuleWrapper.m
+++ b/ios/PlayKit/PlayKit/PlayKitQosModuleWrapper.m
@@ -22,7 +22,7 @@
 
 - (instancetype)init {
     if (self = [super init]) {
-        self.dnaQoSModule = [[StreamrootQosModule alloc] initWithModuleType: QOSModuleTypeCustom];
+        self.dnaQoSModule = [DNAQos moduleWithType:QOSModuleTypeCustom];
         [self registerObservers];
     }
     return self;

--- a/ios/PlayKit/Podfile
+++ b/ios/PlayKit/Podfile
@@ -5,7 +5,7 @@ use_frameworks!
 platform :ios, '9.2' # (define required version)
 
 pod 'PlayKit', :git => 'https://github.com/streamroot/playkit-ios', :branch => 'preferredForwardBufferDuration'
-pod 'StreamrootSDK', '~> 3.12.0'
+pod 'StreamrootSDK'
   
 target 'PlayKit'
 target 'PlayKit-Swift'

--- a/ios/PlayKit/Podfile.lock
+++ b/ios/PlayKit/Podfile.lock
@@ -14,15 +14,15 @@ PODS:
     - SwiftyJSON (= 4.3.0)
     - XCGLogger (= 7.0.0)
   - PlayKitUtils (0.4.0)
-  - Sentry (4.3.1):
-    - Sentry/Core (= 4.3.1)
-  - Sentry/Core (4.3.1)
+  - Sentry (4.4.0):
+    - Sentry/Core (= 4.4.0)
+  - Sentry/Core (4.4.0)
   - Starscream (3.1.0)
-  - StreamrootSDK (3.12.0):
-    - Sentry (= 4.3.1)
+  - StreamrootSDK (3.15.1):
+    - Sentry (= 4.4.0)
     - Starscream (= 3.1.0)
-    - SwiftProtobuf (= 1.4.0)
-  - SwiftProtobuf (1.4.0)
+    - SwiftProtobuf (= 1.6.0)
+  - SwiftProtobuf (1.6.0)
   - SwiftyJSON (4.3.0)
   - XCGLogger (7.0.0):
     - XCGLogger/Core (= 7.0.0)
@@ -31,7 +31,7 @@ PODS:
 
 DEPENDENCIES:
   - PlayKit (from `https://github.com/streamroot/playkit-ios`, branch `preferredForwardBufferDuration`)
-  - StreamrootSDK (~> 3.12.0)
+  - StreamrootSDK
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -58,15 +58,15 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   KalturaNetKit: bd5a963f23f3917a059ac374406143fe2d29bf27
   ObjcExceptionBridging: c30e00eb3700467e695faeea30e26e18bd445001
-  PlayKit: 1ec0792d81a37f0be6704a21c9f5a125750c9593
+  PlayKit: 46da5b32b306122fda6232547234d7fe9a3bb77b
   PlayKitUtils: 98bffe139cffe5cb1fe8fc757b58845c939caf67
-  Sentry: 5267d493a398663538317e4dcc438c12c66202ed
+  Sentry: 26650184fe71eb7476dfd2737acb5ea6cc64b4b1
   Starscream: 08172b481e145289c4930cb567230fb55897cfa4
-  StreamrootSDK: e1e7bc26e70c406fb3ae902cf45bf081c18f4cd2
-  SwiftProtobuf: b06646ed6cdcfc3fecd074c6000fe0c413140e4f
+  StreamrootSDK: 9c7616fe7ba17b921ed4d73d8b8a051027c22690
+  SwiftProtobuf: e905ca1366405696411aaf174411c4b19c0ef73d
   SwiftyJSON: 6faa0040f8b59dead0ee07436cbf76b73c08fd08
   XCGLogger: 0434f15e3909cdc450bb63faf638b8792ab782ab
 
-PODFILE CHECKSUM: a7a3fe2e3469aa96103929617d4fa3936cb4b206
+PODFILE CHECKSUM: f4b1764d4f08420525a7d983bf1f948d33541e57
 
 COCOAPODS: 1.7.5

--- a/ios/PlayKitOVPStarter/PlayKitOVPStarter/PlayKitQoSModule.swift
+++ b/ios/PlayKitOVPStarter/PlayKitOVPStarter/PlayKitQoSModule.swift
@@ -12,7 +12,7 @@ import StreamrootSDK
 // Streamroot QoS module
 // Binds player' events to raise precise data to DNAClient
 class PlayKitQoSModule {
-    let dnaQoSModule: QosModule = StreamrootQosModule(moduleType: .custom)
+    let dnaQoSModule: QosModule = DNAQos.module(type: .custom)
 
     public init(_ player: Player) {
         player.addObserver(self, event: PlayerEvent.stateChanged, block: { event in

--- a/ios/PlayKitOVPStarter/Podfile
+++ b/ios/PlayKitOVPStarter/Podfile
@@ -9,6 +9,6 @@ pod 'PlayKit', :git => 'https://github.com/streamroot/playkit-ios', :branch => '
 pod 'PlayKitProviders'
 pod 'PlayKitKava'
 
-pod 'StreamrootSDK', '~> 3.12.0'
+pod 'StreamrootSDK'
   
 target 'PlayKitOVPStarter'

--- a/ios/PlayKitOVPStarter/Podfile.lock
+++ b/ios/PlayKitOVPStarter/Podfile.lock
@@ -24,15 +24,15 @@ PODS:
     - PlayKitUtils
     - SwiftyXMLParser (= 5.0.0)
   - PlayKitUtils (0.4.0)
-  - Sentry (4.3.1):
-    - Sentry/Core (= 4.3.1)
-  - Sentry/Core (4.3.1)
+  - Sentry (4.4.0):
+    - Sentry/Core (= 4.4.0)
+  - Sentry/Core (4.4.0)
   - Starscream (3.1.0)
-  - StreamrootSDK (3.12.0):
-    - Sentry (= 4.3.1)
+  - StreamrootSDK (3.15.1):
+    - Sentry (= 4.4.0)
     - Starscream (= 3.1.0)
-    - SwiftProtobuf (= 1.4.0)
-  - SwiftProtobuf (1.4.0)
+    - SwiftProtobuf (= 1.6.0)
+  - SwiftProtobuf (1.6.0)
   - SwiftyJSON (4.3.0)
   - SwiftyXMLParser (5.0.0)
   - XCGLogger (7.0.0):
@@ -44,7 +44,7 @@ DEPENDENCIES:
   - PlayKit (from `https://github.com/streamroot/playkit-ios`, branch `preferredForwardBufferDuration`)
   - PlayKitKava
   - PlayKitProviders
-  - StreamrootSDK (~> 3.12.0)
+  - StreamrootSDK
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -78,14 +78,14 @@ SPEC CHECKSUMS:
   PlayKitKava: 82e9b95dc487b9b4e71d4e62f4aa61362515ca51
   PlayKitProviders: 47acfb2a297b9ea01fa89539614b97e6ab95a1f0
   PlayKitUtils: 98bffe139cffe5cb1fe8fc757b58845c939caf67
-  Sentry: 5267d493a398663538317e4dcc438c12c66202ed
+  Sentry: 26650184fe71eb7476dfd2737acb5ea6cc64b4b1
   Starscream: 08172b481e145289c4930cb567230fb55897cfa4
-  StreamrootSDK: e1e7bc26e70c406fb3ae902cf45bf081c18f4cd2
-  SwiftProtobuf: b06646ed6cdcfc3fecd074c6000fe0c413140e4f
+  StreamrootSDK: 9c7616fe7ba17b921ed4d73d8b8a051027c22690
+  SwiftProtobuf: e905ca1366405696411aaf174411c4b19c0ef73d
   SwiftyJSON: 6faa0040f8b59dead0ee07436cbf76b73c08fd08
   SwiftyXMLParser: 5ebb8793192f403fa8cc691045143906122a7a75
   XCGLogger: 0434f15e3909cdc450bb63faf638b8792ab782ab
 
-PODFILE CHECKSUM: 0ecec85e50fde69d1f001377081f794d795d833c
+PODFILE CHECKSUM: f8bbd861f5aee3e850b7c29ddd7053a2e1cefb1a
 
 COCOAPODS: 1.7.5

--- a/ios/README.md
+++ b/ios/README.md
@@ -5,6 +5,6 @@
 
 </div>
 
-> The purpose of this reference application is to provide a fully integrated example application, using Streamroot's SDK and [`AVPlayer`](https://developer.apple.com/documentation/avfoundation/avplayer?changes=_7) as described in our [documentation](https://support.streamroot.io/hc/en-us/sections/115000729153-iOS-and-tvOS).
+> The purpose of this reference application is to provide a fully integrated example application, using Streamroot's SDK and [`AVPlayer`](https://developer.apple.com/documentation/avfoundation/avplayer?changes=_7) as described in our [documentation](https://support.streamroot.io/hc/en-us/sections/360003738414-iOS-and-tvOS).
 
 For any trouble or question, please contact support@streamroot.io


### PR DESCRIPTION
https://github.com/streamroot/tech-board/issues/776
Update the samples of https://github.com/streamroot/dna-integration-samples/ with the latest DNA iOS version 3.15.0
-> Updated to version 3.15.1
-> SSAI is to be tested if possible when a stream is available