### PR TITLE
Android - Update to SDK 3.21.0

### DIFF
--- a/android/AMP/app/build.gradle
+++ b/android/AMP/app/build.gradle
@@ -38,7 +38,7 @@ repositories {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    def dna_version = "3.18.0"
+    def dna_version = "3.21.0"
     implementation "io.streamroot.dna:dna-core:$dna_version"
     implementation "io.streamroot.dna:dna-utils:$dna_version"
 

--- a/android/AMP/app/src/main/java/io/streamroot/dna/samples/amp/AMPSRConfig.kt
+++ b/android/AMP/app/src/main/java/io/streamroot/dna/samples/amp/AMPSRConfig.kt
@@ -1,10 +1,7 @@
 package io.streamroot.dna.samples.amp
 
 import android.content.Context
-import android.os.Handler
-import android.os.HandlerThread
 import io.streamroot.dna.core.Configure
-import io.streamroot.dna.core.OptionalConfigBuilder
 import io.streamroot.dna.core.log.LogLevel
 import java.io.BufferedReader
 import java.io.InputStreamReader
@@ -28,6 +25,6 @@ object AMPSRConfig {
     // You can build DNA instance here
     fun configureStreamroot(baseConfig: Configure) = baseConfig.apply {
         latency(30)
-        logLevel(LogLevel.VERBOSE)
+        logLevel(LogLevel.DEBUG)
     }
 }

--- a/android/AllSamples/build.gradle
+++ b/android/AllSamples/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.0'
+        classpath 'com.android.tools.build:gradle:4.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/android/AllSamples/gradle/wrapper/gradle-wrapper.properties
+++ b/android/AllSamples/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip

--- a/android/Brightcove/app/build.gradle
+++ b/android/Brightcove/app/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation 'com.google.android.exoplayer:exoplayer:2.9.6'
     implementation "com.brightcove.player:exoplayer2:6.8.1"
 
-    def dna_version = "3.18.0"
+    def dna_version = "3.21.0"
     implementation "io.streamroot.dna:dna-core:$dna_version"
     implementation "io.streamroot.dna:dna-utils:$dna_version"
 }

--- a/android/Brightcove/app/src/main/java/io/streamroot/dna/samples/brightcove/PlayerActivity.java
+++ b/android/Brightcove/app/src/main/java/io/streamroot/dna/samples/brightcove/PlayerActivity.java
@@ -92,7 +92,7 @@ public class PlayerActivity extends BrightcovePlayer {
                         .qosModule(qosModule)
 //                        .contentId(videoId)
                         .bandwidthListener(bandwidthListener)
-                        .logLevel(LogLevel.VERBOSE)
+                        .logLevel(LogLevel.DEBUG)
                         .latency(30)// Recommended setting (only on live)
                         .start(Uri.parse(firstHlsSource.getUrl()));
 

--- a/android/ExoPlayer-Java/app/build.gradle
+++ b/android/ExoPlayer-Java/app/build.gradle
@@ -28,7 +28,7 @@ android {
 dependencies {
     implementation 'com.google.android.exoplayer:exoplayer:2.11.3'
 
-    def dna_version = "3.18.0"
+    def dna_version = "3.21.0"
     implementation "io.streamroot.dna:dna-core:$dna_version"
     implementation "io.streamroot.dna:dna-utils:$dna_version"
 

--- a/android/ExoPlayer-pre2.10-Java/app/build.gradle
+++ b/android/ExoPlayer-pre2.10-Java/app/build.gradle
@@ -28,7 +28,7 @@ android {
 dependencies {
     implementation 'com.google.android.exoplayer:exoplayer:2.10.8'
 
-    def dna_version = "3.18.0"
+    def dna_version = "3.21.0"
     implementation "io.streamroot.dna:dna-core:$dna_version"
     implementation "io.streamroot.dna:dna-utils:$dna_version"
 

--- a/android/ExoPlayer-pre2.10/app/build.gradle
+++ b/android/ExoPlayer-pre2.10/app/build.gradle
@@ -32,7 +32,7 @@ android {
 dependencies {
     implementation 'com.google.android.exoplayer:exoplayer:2.10.8'
 
-    def dna_version = "3.18.0"
+    def dna_version = "3.21.0"
     implementation "io.streamroot.dna:dna-core:$dna_version"
     implementation "io.streamroot.dna:dna-utils:$dna_version"
 

--- a/android/ExoPlayer/app/build.gradle
+++ b/android/ExoPlayer/app/build.gradle
@@ -32,7 +32,7 @@ android {
 dependencies {
     implementation 'com.google.android.exoplayer:exoplayer:2.11.3'
 
-    def dna_version = "3.18.0"
+    def dna_version = "3.21.0"
     implementation "io.streamroot.dna:dna-core:$dna_version"
     implementation "io.streamroot.dna:dna-utils:$dna_version"
 

--- a/android/PlayKit/app/build.gradle
+++ b/android/PlayKit/app/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     // Streamroot's up-to-date fork of Kaltura Playkit
     implementation 'com.kaltura.playkit:playkit:4.3.0'
 
-    def dna_version = "3.18.0"
+    def dna_version = "3.21.0"
     implementation "io.streamroot.dna:dna-core:$dna_version"
     implementation "io.streamroot.dna:dna-utils:$dna_version"
 

--- a/android/PlayKit/app/src/main/java/io/streamroot/dna/samples/playkit/PlayKitCustomBandwidthMeter.java
+++ b/android/PlayKit/app/src/main/java/io/streamroot/dna/samples/playkit/PlayKitCustomBandwidthMeter.java
@@ -1,11 +1,13 @@
 package io.streamroot.dna.samples.playkit;
 
 import android.os.Handler;
+
+import androidx.annotation.Nullable;
+
 import com.kaltura.android.exoplayer2.upstream.BandwidthMeter;
 import com.kaltura.android.exoplayer2.upstream.TransferListener;
 import io.streamroot.dna.core.BandwidthListener;
 
-import javax.annotation.Nullable;
 import java.util.concurrent.atomic.AtomicLong;
 
 final class PlayKitCustomBandwidthMeter implements BandwidthMeter, BandwidthListener {

--- a/android/PlayKitOVPStarter/app/build.gradle
+++ b/android/PlayKitOVPStarter/app/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     // Streamroot's up-to-date fork of Kaltura Playkit
     implementation 'com.kaltura.playkit:dna-playkit:3.9.3'
 
-    def dna_version = "3.18.0"
+    def dna_version = "3.21.0"
     implementation "io.streamroot.dna:dna-core:$dna_version"
     implementation "io.streamroot.dna:dna-utils:$dna_version"
 

--- a/android/VideoView/app/build.gradle
+++ b/android/VideoView/app/build.gradle
@@ -27,7 +27,7 @@ android {
 }
 
 dependencies {
-    def dna_version = "3.18.0"
+    def dna_version = "3.21.0"
     implementation "io.streamroot.dna:dna-core:$dna_version"
     implementation "io.streamroot.dna:dna-utils:$dna_version"
 

--- a/android/publish_dna.sh
+++ b/android/publish_dna.sh
@@ -1,11 +1,13 @@
 #!/bin/sh
 
+set -eo pipefail
+
 echo 'Make sure you are logged in to firebase using Firebase CLI "firebase login"'
 
 echo 'Available targets : ExoPlayer | ExoPlayer-Java | ExoPlayer-pre2.10 | ExoPlayer-pre2.10-Java | PlayKit | PlayKitOVPStarter | VideoView | Brightcove | AMP'
 read -p 'Specify project module ? : ' module
 
-firebase --project streamroot-tools apps:list ANDROID
+firebase --project streamroot-tools apps:list ANDROID | grep Samples
 read -p 'Specify Firebase App ID ? : ' fir_app
 
 read -p 'Release notes ? : ' fir_release_notes

--- a/android/update_dna.sh
+++ b/android/update_dna.sh
@@ -4,6 +4,8 @@
 # Android studio / sdk / ndks need to be installed and set on host machine
 # Tested with OSX
 
+set -eo pipefail
+
 YELLOW="\033[1;33m"
 RST="\033[0m"
 


### PR DESCRIPTION
- Fixed VERBOSE log level (removed)
- Pipefail in build/publish scripts android
- Android nullable instead of java's nullable annotation
- Android samples now using SDK 3.21.0